### PR TITLE
Move filter scripts into tools, refactor measure_judged script

### DIFF
--- a/eval/measure_judged.py
+++ b/eval/measure_judged.py
@@ -1,19 +1,20 @@
-# -*- coding: utf-8 -*-
-"""
-Anserini: A Lucene toolkit for replicable information retrieval research
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Compute the fraction of judged documents at various cutoffs."""
 
 import argparse
 import collections
@@ -24,8 +25,7 @@ from typing import Set
 
 
 def load_qrels(path: str) -> Dict[str, Set[str]]:
-    """Loads qrels into a dict of key: query_id, value: set of relevant doc
-    ids."""
+    """Loads qrels into a dict of key: query_id, value: set of relevant doc ids."""
     qrels = collections.defaultdict(set)
     with open(path) as f:
         for i, line in enumerate(f):
@@ -37,8 +37,7 @@ def load_qrels(path: str) -> Dict[str, Set[str]]:
 
 
 def load_run(path: str) -> Dict[str, List[str]]:
-    """Loads run into a dict of key: query_id, value: list of candidate doc
-    ids."""
+    """Loads run into a dict of key: query_id, value: list of candidate doc ids."""
     run = collections.OrderedDict()
     with open(path) as f:
         for line in f:
@@ -57,18 +56,14 @@ def load_run(path: str) -> Dict[str, List[str]]:
     return sorted_run
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description='measure the percentage of judged documents at various '
-                    'cutoffs.')
-    parser.add_argument('--qrels', type=str, required=True, help='qrels file')
-    parser.add_argument('--run', type=str, required=True, help='run file')
-    parser.add_argument('--cutoffs', nargs='+', type=int,
-                        default=[5, 10, 20, 30],
-                        help='Space-separate list of cutoffs. '
-                             'E.g.: --cutoffs 5 10 20')
-    parser.add_argument('-q', action='store_true', dest='print_topic',
-                        help='In addition to summary evaluation, give evaluation for each query/topic')
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=lambda prog: argparse.HelpFormatter(prog, width=100))
+    parser.add_argument('--qrels', metavar='FILE', type=str, required=True, help='Qrels file.')
+    parser.add_argument('--run', metavar='FILE', type=str, required=True, help='Run file.')
+    parser.add_argument('--cutoffs', metavar='N', nargs='+', type=int, default=[10, 100, 1000],
+                        help='Space-separate list of cutoffs, e.g., --cutoffs 10 100 1000.')
+    parser.add_argument('--q', '-q', action='store_true', dest='print_topic', help='Print metrics per topic.')
 
     args = parser.parse_args()
 
@@ -89,4 +84,6 @@ if __name__ == "__main__":
         percentage_judged /= max(1, len(run))
         print(f'judged_cut_{max_rank}\tall\t{percentage_judged:.4f}')
 
-    print('\nDone')
+
+if __name__ == "__main__":
+    main()

--- a/scripts/filter_run.py
+++ b/scripts/filter_run.py
@@ -1,0 +1,79 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Filter a TREC run file to retain only docids that appear on a list of valid docids (commonly known as a whitelist).
+The whitelist is a file with a docid on each line."""
+
+import argparse
+from collections import defaultdict
+
+
+def read_file(file):
+    docids = set()
+    with open(file) as f:
+        for line in f:
+            cols = line.split()
+            if len(cols) > 0:
+                docids.add(cols[0])
+    return docids
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=lambda prog: argparse.HelpFormatter(prog, width=100))
+    parser.add_argument('--whitelist', metavar='FILE', type=str, help='Whitelist (one docid per line).', required=True)
+    parser.add_argument('--input', metavar='FILE', type=str, help='Input run.', required=True)
+    parser.add_argument('--output', metavar='FILE', type=str, help='Output run.', required=True)
+    parser.add_argument('--runtag', metavar='STRING', type=str, default=None, help='Runtag.')
+    parser.add_argument('--k', metavar='NUM', type=int, default=1000, help='Number of hits to retain per topic.')
+    args = parser.parse_args()
+
+    docids = read_file(args.whitelist)
+    print(f'Read {len(docids)} docids from {args.whitelist}')
+    counts = defaultdict(int)
+
+    prev_score = None
+    check_score = True
+    with open(args.output, 'w') as output_f:
+        with open(args.input) as input_f:
+            for line in input_f:
+                cols = line.split()
+                qid = cols[0]
+                docid = cols[2]
+                score = float(cols[4])
+                tag = cols[5]
+
+                if args.runtag:
+                    tag = args.runtag
+
+                if counts[qid] >= args.k:
+                    if check_score:
+                        if score <= prev_score:
+                            print(f'Warning: scores of {qid} do not strictly decrease at {docid}')
+                        check_score = False
+                        continue
+                    else:
+                        continue
+
+                if docid in docids:
+                    counts[qid] += 1
+                    prev_score = float(cols[4])
+                    check_score = True
+                    output_f.write(f'{qid} Q0 {docid} {counts[qid]} {score} {tag}\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/filter_run_with_qrels.py
+++ b/scripts/filter_run_with_qrels.py
@@ -1,0 +1,95 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Filter a TREC run file to either retain only docids that are judged (--retain) or throw away documents that are
+judged (--discard)."""
+
+import argparse
+import sys
+from collections import defaultdict
+
+
+def load_qrels(qrels):
+    judged_docids = defaultdict(set)
+    with open(qrels) as f:
+        for line in f:
+            cols = line.split()
+            qid = cols[0]
+            docid = cols[2]
+            judged_docids[qid].add(docid)
+    return judged_docids
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=lambda prog: argparse.HelpFormatter(prog, width=100))
+    parser.add_argument('--qrels', metavar='FILE', type=str, help='Qrels.', required=True)
+    parser.add_argument('--input', metavar='FILE', type=str, help='Input run.', required=True)
+    parser.add_argument('--output', metavar='FILE', type=str, help='Output run.', required=True)
+    parser.add_argument('--runtag', metavar='STRING', type=str, default=None, help='Runtag.')
+    parser.add_argument('--k', metavar='NUM', type=int, default=1000, help='Number of hits to retain per topic.')
+    parser.add_argument('--retain', action='store_true',
+                        help="Retain judged docids, i.e., throw away all unjudged documents.")
+    parser.add_argument('--discard', action='store_true',
+                        help="Discard judged docids, i.e., keep only documents that are unjudged.")
+    args = parser.parse_args()
+
+    if (args.retain and args.discard) or (not args.retain and not args.discard):
+        print('Must specific either one of --retain or --discard.')
+        return
+
+    judged_docids = load_qrels(args.qrels)
+    counts = defaultdict(int)
+
+    prev_score = None
+    check_score = True
+    with open(args.output, 'w') as output_f:
+        with open(args.input) as input_f:
+            for line in input_f:
+                cols = line.split()
+                qid = cols[0]
+                docid = cols[2]
+                score = float(cols[4])
+                tag = cols[5]
+
+                if args.runtag:
+                    tag = args.runtag
+
+                if counts[qid] >= args.k:
+                    if check_score:
+                        if score <= prev_score:
+                            print(f'Warning: scores of {qid} do not strictly decrease at {docid}')
+                        check_score = False
+                        continue
+                    else:
+                        continue
+
+                if args.discard:
+                    if qid not in judged_docids or docid not in judged_docids[qid]:
+                        counts[qid] += 1
+                        prev_score = float(cols[4])
+                        check_score = True
+                        output_f.write(f'{qid} Q0 {docid} {counts[qid]} {score} {tag}\n')
+                elif args.retain:
+                    if qid in judged_docids and docid in judged_docids[qid]:
+                        counts[qid] += 1
+                        prev_score = float(cols[4])
+                        check_score = True
+                        output_f.write(f'{qid} Q0 {docid} {counts[qid]} {score} {tag}\n')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Filter scripts were previously in anserini, under `src/main/python/trec-covid/`. Moved to here because they're not specific to TREC-COVID, but should be shared as common scripts.