### PR TITLE
Fix bug (sorted not in-place)

### DIFF
--- a/eval/measure_judged.py
+++ b/eval/measure_judged.py
@@ -49,7 +49,7 @@ def load_run(path: str) -> Dict[str, List[str]]:
     # Sort candidate docs by rank.
     sorted_run = collections.OrderedDict()
     for query_id, doc_titles_ranks in run.items():
-        sorted(doc_titles_ranks, key=lambda x: x[1])
+        doc_titles_ranks.sort(key=lambda x: x[1])
         doc_titles = [doc_titles for doc_titles, _ in doc_titles_ranks]
         sorted_run[query_id] = doc_titles
 


### PR DESCRIPTION
Switch out sorted to sort. The sorted function, the way it is used here doesn't do anything as it is in-place. This has been a silent bug that hasn't resulted in any issues.